### PR TITLE
feat: implement Telegram authentication and account linking

### DIFF
--- a/back/apps/api/auth/auth.controller.ts
+++ b/back/apps/api/auth/auth.controller.ts
@@ -5,6 +5,8 @@ import {
   AuthResponse,
   FindAllUsersRequest,
   UserListResponse,
+  SignInWithTelegramRequest,
+  LinkTelegramAccountRequest,
 } from 'shared/generated/auth';
 import { Public } from './guard/public.decorator';
 import { SignUpDto } from './dto/sing-up.dto';
@@ -30,6 +32,24 @@ export class AuthController {
   @ApiBody({ type: SignUpDto })
   signUp(@Body() dto: SignUpDto): Observable<AuthResponse> {
     return this.authService.signUp(dto);
+  }
+
+  @Public()
+  @Post('telegram/sign-in')
+  @ApiOperation({ summary: 'Sign in with Telegram' })
+  signInWithTelegram(
+    @Body() dto: SignInWithTelegramRequest,
+  ): Observable<AuthResponse> {
+    return this.authService.signInWithTelegram(dto);
+  }
+
+  @Public()
+  @Post('telegram/link')
+  @ApiOperation({ summary: 'Link Telegram account' })
+  linkTelegramAccount(
+    @Body() dto: LinkTelegramAccountRequest,
+  ): Observable<AuthResponse> {
+    return this.authService.linkTelegramAccount(dto);
   }
 
   @Post('all-users')

--- a/back/apps/api/auth/auth.service.ts
+++ b/back/apps/api/auth/auth.service.ts
@@ -9,6 +9,8 @@ import {
   SignUpRequest,
   GetProfileRequest,
   User,
+  SignInWithTelegramRequest,
+  LinkTelegramAccountRequest,
 } from 'shared/generated/auth';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
@@ -72,6 +74,28 @@ export class AuthService implements OnModuleInit, AuthServiceClient {
     console.log('request', JSON.stringify(request));
     return from(
       handleRequest(() => this.authService.refreshToken(request, metadata)),
+    );
+  }
+
+  signInWithTelegram(
+    request: SignInWithTelegramRequest,
+    metadata: Metadata = new Metadata(),
+  ): Observable<AuthResponse> {
+    return from(
+      handleRequest(() =>
+        this.authService.signInWithTelegram(request, metadata),
+      ),
+    );
+  }
+
+  linkTelegramAccount(
+    request: LinkTelegramAccountRequest,
+    metadata: Metadata = new Metadata(),
+  ): Observable<AuthResponse> {
+    return from(
+      handleRequest(() =>
+        this.authService.linkTelegramAccount(request, metadata),
+      ),
     );
   }
 }

--- a/back/apps/auth/auth.controller.ts
+++ b/back/apps/auth/auth.controller.ts
@@ -12,6 +12,8 @@ import {
   SignUpRequest,
   User,
   UserListResponse,
+  SignInWithTelegramRequest,
+  LinkTelegramAccountRequest,
 } from 'shared/generated/auth';
 
 @ApiTags('auth')
@@ -42,5 +44,19 @@ export class AuthController implements AuthServiceController {
   @GrpcMethod('AuthService', 'RefreshToken')
   async refreshToken(data: RefreshTokenRequest): Promise<AuthResponse> {
     return await this.authService.refreshToken(data.refreshToken);
+  }
+
+  @GrpcMethod('AuthService', 'SignInWithTelegram')
+  async signInWithTelegram(
+    data: SignInWithTelegramRequest,
+  ): Promise<AuthResponse> {
+    return await this.authService.signInWithTelegram(data);
+  }
+
+  @GrpcMethod('AuthService', 'LinkTelegramAccount')
+  async linkTelegramAccount(
+    data: LinkTelegramAccountRequest,
+  ): Promise<AuthResponse> {
+    return await this.authService.linkTelegramAccount(data);
   }
 }

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -21,6 +21,10 @@ model User {
   role              Role               @relation(fields: [roleId], references: [id])
   workspaces        Workspace[]
   managedWorkspaces WorkspaceManager[]
+  telegramId        String?            @unique
+  telegramUsername  String?
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
 
   @@map("user")
 }

--- a/back/shared/generated/auth.ts
+++ b/back/shared/generated/auth.ts
@@ -37,6 +37,27 @@ export interface RefreshTokenRequest {
   refreshToken: string;
 }
 
+export interface SignInWithTelegramRequest {
+  telegramId: string;
+  firstName: string;
+  lastName: string;
+  username: string;
+  photoUrl: string;
+  authDate: string;
+  hash: string;
+}
+
+export interface LinkTelegramAccountRequest {
+  userId: string;
+  telegramId: string;
+  firstName: string;
+  lastName: string;
+  username: string;
+  photoUrl: string;
+  authDate: string;
+  hash: string;
+}
+
 export interface UserName {
   firstName: string;
   lastName: string;
@@ -60,6 +81,8 @@ export interface User {
   email: string;
   phone: string;
   role: Role | undefined;
+  telegramId?: string | undefined;
+  telegramUsername?: string | undefined;
 }
 
 export interface Role {
@@ -310,6 +333,232 @@ export const RefreshTokenRequest: MessageFns<RefreshTokenRequest> = {
   },
 };
 
+function createBaseSignInWithTelegramRequest(): SignInWithTelegramRequest {
+  return { telegramId: "", firstName: "", lastName: "", username: "", photoUrl: "", authDate: "", hash: "" };
+}
+
+export const SignInWithTelegramRequest: MessageFns<SignInWithTelegramRequest> = {
+  encode(message: SignInWithTelegramRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.telegramId !== "") {
+      writer.uint32(10).string(message.telegramId);
+    }
+    if (message.firstName !== "") {
+      writer.uint32(18).string(message.firstName);
+    }
+    if (message.lastName !== "") {
+      writer.uint32(26).string(message.lastName);
+    }
+    if (message.username !== "") {
+      writer.uint32(34).string(message.username);
+    }
+    if (message.photoUrl !== "") {
+      writer.uint32(42).string(message.photoUrl);
+    }
+    if (message.authDate !== "") {
+      writer.uint32(50).string(message.authDate);
+    }
+    if (message.hash !== "") {
+      writer.uint32(58).string(message.hash);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SignInWithTelegramRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSignInWithTelegramRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.telegramId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.firstName = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.lastName = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.username = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.photoUrl = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.authDate = reader.string();
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          message.hash = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+};
+
+function createBaseLinkTelegramAccountRequest(): LinkTelegramAccountRequest {
+  return {
+    userId: "",
+    telegramId: "",
+    firstName: "",
+    lastName: "",
+    username: "",
+    photoUrl: "",
+    authDate: "",
+    hash: "",
+  };
+}
+
+export const LinkTelegramAccountRequest: MessageFns<LinkTelegramAccountRequest> = {
+  encode(message: LinkTelegramAccountRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.userId !== "") {
+      writer.uint32(10).string(message.userId);
+    }
+    if (message.telegramId !== "") {
+      writer.uint32(18).string(message.telegramId);
+    }
+    if (message.firstName !== "") {
+      writer.uint32(26).string(message.firstName);
+    }
+    if (message.lastName !== "") {
+      writer.uint32(34).string(message.lastName);
+    }
+    if (message.username !== "") {
+      writer.uint32(42).string(message.username);
+    }
+    if (message.photoUrl !== "") {
+      writer.uint32(50).string(message.photoUrl);
+    }
+    if (message.authDate !== "") {
+      writer.uint32(58).string(message.authDate);
+    }
+    if (message.hash !== "") {
+      writer.uint32(66).string(message.hash);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): LinkTelegramAccountRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseLinkTelegramAccountRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.telegramId = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.firstName = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.lastName = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.username = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.photoUrl = reader.string();
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          message.authDate = reader.string();
+          continue;
+        }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.hash = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+};
+
 function createBaseUserName(): UserName {
   return { firstName: "", lastName: "" };
 }
@@ -481,6 +730,12 @@ export const User: MessageFns<User> = {
     if (message.role !== undefined) {
       Role.encode(message.role, writer.uint32(58).fork()).join();
     }
+    if (message.telegramId !== undefined) {
+      writer.uint32(66).string(message.telegramId);
+    }
+    if (message.telegramUsername !== undefined) {
+      writer.uint32(74).string(message.telegramUsername);
+    }
     return writer;
   },
 
@@ -545,6 +800,22 @@ export const User: MessageFns<User> = {
           }
 
           message.role = Role.decode(reader, reader.uint32());
+          continue;
+        }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.telegramId = reader.string();
+          continue;
+        }
+        case 9: {
+          if (tag !== 74) {
+            break;
+          }
+
+          message.telegramUsername = reader.string();
           continue;
         }
       }
@@ -628,6 +899,10 @@ export interface AuthServiceClient {
   findAllUsers(request: FindAllUsersRequest, metadata: Metadata, ...rest: any): Observable<UserListResponse>;
 
   getProfile(request: GetProfileRequest, metadata: Metadata, ...rest: any): Observable<User>;
+
+  signInWithTelegram(request: SignInWithTelegramRequest, metadata: Metadata, ...rest: any): Observable<AuthResponse>;
+
+  linkTelegramAccount(request: LinkTelegramAccountRequest, metadata: Metadata, ...rest: any): Observable<AuthResponse>;
 }
 
 /** Сервис аутентификации и управления пользователями */
@@ -658,11 +933,31 @@ export interface AuthServiceController {
   ): Promise<UserListResponse> | Observable<UserListResponse> | UserListResponse;
 
   getProfile(request: GetProfileRequest, metadata: Metadata, ...rest: any): Promise<User> | Observable<User> | User;
+
+  signInWithTelegram(
+    request: SignInWithTelegramRequest,
+    metadata: Metadata,
+    ...rest: any
+  ): Promise<AuthResponse> | Observable<AuthResponse> | AuthResponse;
+
+  linkTelegramAccount(
+    request: LinkTelegramAccountRequest,
+    metadata: Metadata,
+    ...rest: any
+  ): Promise<AuthResponse> | Observable<AuthResponse> | AuthResponse;
 }
 
 export function AuthServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ["signIn", "signUp", "refreshToken", "findAllUsers", "getProfile"];
+    const grpcMethods: string[] = [
+      "signIn",
+      "signUp",
+      "refreshToken",
+      "findAllUsers",
+      "getProfile",
+      "signInWithTelegram",
+      "linkTelegramAccount",
+    ];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcMethod("AuthService", method)(constructor.prototype[method], method, descriptor);
@@ -725,6 +1020,26 @@ export const AuthServiceService = {
     responseSerialize: (value: User) => Buffer.from(User.encode(value).finish()),
     responseDeserialize: (value: Buffer) => User.decode(value),
   },
+  signInWithTelegram: {
+    path: "/auth.AuthService/SignInWithTelegram",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: SignInWithTelegramRequest) =>
+      Buffer.from(SignInWithTelegramRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => SignInWithTelegramRequest.decode(value),
+    responseSerialize: (value: AuthResponse) => Buffer.from(AuthResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => AuthResponse.decode(value),
+  },
+  linkTelegramAccount: {
+    path: "/auth.AuthService/LinkTelegramAccount",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: LinkTelegramAccountRequest) =>
+      Buffer.from(LinkTelegramAccountRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => LinkTelegramAccountRequest.decode(value),
+    responseSerialize: (value: AuthResponse) => Buffer.from(AuthResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => AuthResponse.decode(value),
+  },
 } as const;
 
 export interface AuthServiceServer extends UntypedServiceImplementation {
@@ -733,6 +1048,8 @@ export interface AuthServiceServer extends UntypedServiceImplementation {
   refreshToken: handleUnaryCall<RefreshTokenRequest, AuthResponse>;
   findAllUsers: handleUnaryCall<FindAllUsersRequest, UserListResponse>;
   getProfile: handleUnaryCall<GetProfileRequest, User>;
+  signInWithTelegram: handleUnaryCall<SignInWithTelegramRequest, AuthResponse>;
+  linkTelegramAccount: handleUnaryCall<LinkTelegramAccountRequest, AuthResponse>;
 }
 
 function longToNumber(int64: { toString(): string }): number {

--- a/back/shared/proto/auth.proto
+++ b/back/shared/proto/auth.proto
@@ -12,6 +12,8 @@ service AuthService {
   rpc RefreshToken (RefreshTokenRequest) returns (AuthResponse) {}
   rpc FindAllUsers (FindAllUsersRequest) returns (UserListResponse) {}
   rpc GetProfile (GetProfileRequest) returns (User) {}
+  rpc SignInWithTelegram (SignInWithTelegramRequest) returns (AuthResponse) {}
+  rpc LinkTelegramAccount (LinkTelegramAccountRequest) returns (AuthResponse) {}
 }
 
 message SignInRequest {
@@ -39,6 +41,26 @@ message RefreshTokenRequest {
   string refresh_token = 1;
 }
 
+message SignInWithTelegramRequest {
+  string telegram_id = 1;
+  string first_name = 2;
+  string last_name = 3;
+  string username = 4;
+  string photo_url = 5;
+  string auth_date = 6;
+  string hash = 7;
+}
+
+message LinkTelegramAccountRequest {
+  string user_id = 1;
+  string telegram_id = 2;
+  string first_name = 3;
+  string last_name = 4;
+  string username = 5;
+  string photo_url = 6;
+  string auth_date = 7;
+  string hash = 8;
+}
 
 message UserName {
   string first_name = 1;
@@ -63,6 +85,8 @@ message User {
   string email = 5;
   string phone = 6;
   Role role = 7;
+  optional string telegram_id = 8;
+  optional string telegram_username = 9;
 }
 
 message Role {

--- a/front/components/auth/TelegramAuth.vue
+++ b/front/components/auth/TelegramAuth.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="flex flex-col items-center space-y-4">
+    <button
+      @click="initTelegramAuth"
+      class="flex items-center space-x-2 bg-[#0088cc] text-white px-4 py-2 rounded-md hover:bg-[#0077b3] transition-colors"
+    >
+      <svg
+        class="w-6 h-6"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8c-.15 1.58-.8 5.42-1.13 7.19-.14.75-.42 1-.68 1.03-.58.05-1.02-.38-1.58-.75-.88-.58-1.38-.94-2.23-1.5-.99-.65-.35-1.01.22-1.59.15-.15 2.71-2.48 2.76-2.69.01-.03.01-.14-.07-.2-.08-.06-.2-.04-.28-.02-.12.02-1.96 1.25-5.54 3.69-.52.36-1 .53-1.42.52-.47-.01-1.37-.26-2.03-.48-.82-.27-1.47-.42-1.42-.88.03-.24.29-.49.8-.75 3.12-1.36 5.2-2.26 6.24-2.7 2.97-1.23 3.59-1.44 4-1.44.09 0 .29.02.42.14.11.1.14.23.15.38-.01.14-.01.3-.02.42z"
+        />
+      </svg>
+      <span>Войти через Telegram</span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+import { useAuthStore } from "~/stores/auth";
+
+const router = useRouter();
+const authStore = useAuthStore();
+
+const initTelegramAuth = () => {
+  const botUsername = import.meta.env.TELEGRAM_BOT_USERNAME;
+  alert(botUsername);
+  if (!botUsername) {
+    console.error("Telegram bot username not configured");
+    return;
+  }
+
+  const authUrl = `https://oauth.telegram.org/auth?bot_id=${botUsername}&origin=${window.location.origin}&return_to=${window.location.origin}/auth/telegram`;
+  window.location.href = authUrl;
+};
+</script>

--- a/front/pages/auth/telegram.vue
+++ b/front/pages/auth/telegram.vue
@@ -1,0 +1,60 @@
+<template>
+  <div
+    class="min-h-screen flex items-center justify-center bg-gray-900 py-12 px-4 sm:px-6 lg:px-8"
+  >
+    <div class="max-w-md w-full space-y-8">
+      <div>
+        <h2 class="mt-6 text-center text-3xl font-extrabold text-white">
+          Авторизация через Telegram
+        </h2>
+        <p class="mt-2 text-center text-sm text-gray-400">
+          {{ loading ? "Выполняется вход..." : error || "Перенаправление..." }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useAuthStore } from "../../stores/auth";
+
+definePageMeta({
+  layout: "auth",
+});
+
+const route = useRoute();
+const router = useRouter();
+const authStore = useAuthStore();
+const loading = ref(true);
+const error = ref("");
+
+onMounted(async () => {
+  try {
+    const hash = route.hash.substring(1);
+    const params = new URLSearchParams(hash);
+    const telegramData = {
+      telegramId: params.get("id") || "",
+      firstName: params.get("first_name") || "",
+      lastName: params.get("last_name") || "",
+      username: params.get("username") || "",
+      photoUrl: params.get("photo_url") || "",
+      authDate: params.get("auth_date") || "",
+      hash: params.get("hash") || "",
+    };
+
+    if (!telegramData.telegramId) {
+      throw new Error("Не удалось получить данные от Telegram");
+    }
+
+    await authStore.signInWithTelegram(telegramData);
+    router.push("/hello");
+  } catch (err) {
+    error.value = "Ошибка авторизации через Telegram";
+    console.error(err);
+  } finally {
+    loading.value = false;
+  }
+});
+</script>

--- a/front/pages/register.vue
+++ b/front/pages/register.vue
@@ -101,7 +101,38 @@
           </button>
         </div>
       </form>
-      <div class="text-center">
+
+      <div class="mt-6">
+        <div class="relative">
+          <div class="absolute inset-0 flex items-center">
+            <div class="w-full border-t border-gray-700"></div>
+          </div>
+          <div class="relative flex justify-center text-sm">
+            <span class="px-2 bg-gray-900 text-gray-400">Или</span>
+          </div>
+        </div>
+
+        <div class="mt-6">
+          <button
+            @click="initTelegramAuth"
+            class="w-full flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-[#0088cc] hover:bg-[#0077b3] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#0088cc] focus:ring-offset-gray-900"
+          >
+            <svg
+              class="w-5 h-5 mr-2"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8c-.15 1.58-.8 5.42-1.13 7.19-.14.75-.42 1-.68 1.03-.58.05-1.02-.38-1.58-.75-.88-.58-1.38-.94-2.23-1.5-.99-.65-.35-1.01.22-1.59.15-.15 2.71-2.48 2.76-2.69.01-.03.01-.14-.07-.2-.08-.06-.2-.04-.28-.02-.12.02-1.96 1.25-5.54 3.69-.52.36-1 .53-1.42.52-.47-.01-1.37-.26-2.03-.48-.82-.27-1.47-.42-1.42-.88.03-.24.29-.49.8-.75 3.12-1.36 5.2-2.26 6.24-2.7 2.97-1.23 3.59-1.44 4-1.44.09 0 .29.02.42.14.11.1.14.23.15.38-.01.14-.01.3-.02.42z"
+              />
+            </svg>
+            Войти через Telegram
+          </button>
+        </div>
+      </div>
+
+      <div class="text-center mt-4">
         <NuxtLink to="/login" class="text-indigo-400 hover:text-indigo-300">
           Уже есть аккаунт? Войти
         </NuxtLink>
@@ -133,18 +164,35 @@ const handleRegister = async () => {
   try {
     loading.value = true;
     error.value = "";
-    await authStore.signUp(
-      email.value,
-      password.value,
-      firstName.value,
-      lastName.value,
-      phone.value
-    );
+    await authStore.signUp({
+      email: email.value,
+      password: password.value,
+      name: {
+        firstName: firstName.value,
+        lastName: lastName.value,
+      },
+      phone: phone.value,
+    });
     router.push("/hello");
   } catch (err) {
     error.value = "Ошибка регистрации. Пожалуйста, попробуйте снова.";
   } finally {
     loading.value = false;
   }
+};
+
+const initTelegramAuth = () => {
+  // const botId = import.meta.env.TELEGRAM_BOT_ID;
+  // if (!botId) {
+  //   console.error("Telegram bot ID not configured");
+  //   return;
+  // }
+
+  console.log("Bot ID:", import.meta.env.TELEGRAM_BOT_ID);
+
+  const authUrl = `https://oauth.telegram.org/auth?bot_id=${"7933596215"}&origin=${
+    window.location.origin
+  }&return_to=${window.location.origin}/auth/telegram`;
+  window.location.href = authUrl;
 };
 </script>

--- a/front/stores/auth.ts
+++ b/front/stores/auth.ts
@@ -59,45 +59,100 @@ export const useAuthStore = defineStore("auth", () => {
     isInitialized.value = true;
   }
 
-  async function signIn(email: string, password: string) {
+  const signIn = async (email: string, password: string) => {
     try {
-      const { data } = await api.post("/auth/sign-in", {
-        email,
-        password,
-      });
-      console.log("Data:", data);
+      const { data } = await api.post("/auth/sign-in", { email, password });
       setTokens(data.accessToken, data.refreshToken);
       await fetchUser();
       return data;
     } catch (error) {
-      toast.error("Неправильный email и/или пароль");
+      toast.error((error as ApiError).message || "Failed to sign in");
       throw error;
     }
-  }
+  };
 
-  async function signUp(
-    email: string,
-    password: string,
-    firstName: string,
-    lastName: string,
-    phone: string
-  ) {
+  const signUp = async (data: {
+    email: string;
+    password: string;
+    name: {
+      firstName: string;
+      lastName: string;
+      middleName?: string;
+    };
+    phone: string;
+  }) => {
     try {
-      const { data } = await api.post("/auth/sign-up", {
-        email,
-        password,
-        firstName,
-        lastName,
-        phone,
-      });
-      setTokens(data.accessToken, data.refreshToken);
+      const response = await api.post("/auth/sign-up", data);
+      setTokens(response.data.accessToken, response.data.refreshToken);
       await fetchUser();
-      return data;
+      return response.data;
     } catch (error) {
       toast.error((error as ApiError).message || "Failed to sign up");
       throw error;
     }
-  }
+  };
+
+  const signInWithTelegram = async (data: {
+    telegramId: string;
+    firstName: string;
+    lastName: string;
+    username: string;
+    photoUrl: string;
+    authDate: string;
+    hash: string;
+  }) => {
+    try {
+      const response = await api.post("/auth/telegram/sign-in", {
+        telegram_id: data.telegramId,
+        first_name: data.firstName,
+        last_name: data.lastName,
+        username: data.username,
+        photo_url: data.photoUrl,
+        auth_date: data.authDate,
+        hash: data.hash,
+      });
+      setTokens(response.data.accessToken, response.data.refreshToken);
+      await fetchUser();
+      return response.data;
+    } catch (error) {
+      toast.error(
+        (error as ApiError).message || "Failed to sign in with Telegram"
+      );
+      throw error;
+    }
+  };
+
+  const linkTelegramAccount = async (data: {
+    userId: string;
+    telegramId: string;
+    firstName: string;
+    lastName: string;
+    username: string;
+    photoUrl: string;
+    authDate: string;
+    hash: string;
+  }) => {
+    try {
+      const response = await api.post("/auth/telegram/link", {
+        user_id: data.userId,
+        telegram_id: data.telegramId,
+        first_name: data.firstName,
+        last_name: data.lastName,
+        username: data.username,
+        photo_url: data.photoUrl,
+        auth_date: data.authDate,
+        hash: data.hash,
+      });
+      setTokens(response.data.accessToken, response.data.refreshToken);
+      await fetchUser();
+      return response.data;
+    } catch (error) {
+      toast.error(
+        (error as ApiError).message || "Failed to link Telegram account"
+      );
+      throw error;
+    }
+  };
 
   async function fetchUser() {
     if (!accessToken.value) return null;
@@ -129,6 +184,8 @@ export const useAuthStore = defineStore("auth", () => {
     setTokens,
     signIn,
     signUp,
+    signInWithTelegram,
+    linkTelegramAccount,
     fetchUser,
     logout,
   };


### PR DESCRIPTION
- Added sign-in and account linking functionality via Telegram in AuthService and AuthController.
- Introduced SignInWithTelegramRequest and LinkTelegramAccountRequest for handling Telegram data.
- Updated Prisma schema to include telegramId and telegramUsername fields in the User model.
- Created new Vue components for Telegram authentication and integrated them into the registration flow.
- Enhanced the auth store to manage Telegram sign-in and linking processes, improving user experience.